### PR TITLE
feat: Implement favorites functionality with Firestore integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .history
 .svn/
 .swiftpm/
+.claude/
 migrate_working_dir/
 
 # IntelliJ related

--- a/lib/controllers/favorites_controller.dart
+++ b/lib/controllers/favorites_controller.dart
@@ -1,33 +1,89 @@
 import 'package:flutter/material.dart';
 import 'package:pokedex_app/models/pokemon.dart';
+import 'package:pokedex_app/services/i_favorites_service.dart';
+
 
 class FavoritesController extends ChangeNotifier {
+  final IFavoritesService _favoritesService;
   final List<Pokemon> _favorites = [];
+  bool _isLoading = false;
+
+  FavoritesController(this._favoritesService) {
+    _loadFavorites();
+  }
 
   List<Pokemon> get favorites => List.unmodifiable(_favorites);
+  bool get isLoading => _isLoading;
+
+
+  Future<void> _loadFavorites() async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      final loadedFavorites = await _favoritesService.getFavorites();
+      _favorites.clear();
+      _favorites.addAll(loadedFavorites);
+    } catch (e) {
+      debugPrint('Error loading favorites: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+ 
+  Future<void> reloadFavorites() async {
+    await _loadFavorites();
+  }
 
   bool isFavorite(Pokemon pokemon) {
     return _favorites.contains(pokemon);
   }
 
-  void toggleFavorite(Pokemon pokemon) {
+  Future<void> toggleFavorite(Pokemon pokemon) async {
     if (isFavorite(pokemon)) {
-      _favorites.remove(pokemon);
+      await removeFavorite(pokemon);
     } else {
-      _favorites.add(pokemon);
+      await addFavorite(pokemon);
     }
-    notifyListeners();
   }
 
-  void addFavorite(Pokemon pokemon) {
+  Future<void> addFavorite(Pokemon pokemon) async {
     if (!isFavorite(pokemon)) {
       _favorites.add(pokemon);
       notifyListeners();
+
+      try {
+        await _favoritesService.addFavorite(pokemon);
+      } catch (e) {
+        debugPrint('Error adding favorite to Firestore: $e');
+       
+        _favorites.remove(pokemon);
+        notifyListeners();
+        rethrow;
+      }
     }
   }
 
-  void removeFavorite(Pokemon pokemon) {
+  Future<void> removeFavorite(Pokemon pokemon) async {
     _favorites.remove(pokemon);
+    notifyListeners();
+
+    try {
+      await _favoritesService.removeFavorite(pokemon.id);
+    } catch (e) {
+      debugPrint('Error removing favorite from Firestore: $e');
+      
+      _favorites.add(pokemon);
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  
+  Future<void> clearFavorites() async {
+    _favorites.clear();
     notifyListeners();
   }
 

--- a/lib/services/favorites_service.dart
+++ b/lib/services/favorites_service.dart
@@ -1,0 +1,102 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:pokedex_app/models/pokemon.dart';
+import 'package:pokedex_app/services/i_favorites_service.dart';
+
+
+enum FirestoreCollection {
+  users,
+  favorites;
+}
+
+enum FavoriteField {
+  name,
+  url,
+  imageUrl,
+  timestamp;
+}
+
+class FavoritesService implements IFavoritesService {
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  FavoritesService({
+    FirebaseFirestore? firestore,
+    FirebaseAuth? auth,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
+
+  String? get _userId => _auth.currentUser?.uid;
+
+  CollectionReference? get _favoritesCollection {
+    if (_userId == null) return null;
+    return _firestore
+        .collection(FirestoreCollection.users.name)
+        .doc(_userId)
+        .collection(FirestoreCollection.favorites.name);
+  }
+
+  @override
+  Future<void> addFavorite(Pokemon pokemon) async {
+    if (_favoritesCollection == null) return;
+
+    await _favoritesCollection!.doc(pokemon.id).set({
+      FavoriteField.name.name: pokemon.name,
+      FavoriteField.url.name: pokemon.url,
+      FavoriteField.imageUrl.name: pokemon.imageUrl,
+      FavoriteField.timestamp.name: FieldValue.serverTimestamp(),
+    });
+  }
+
+  @override
+  Future<void> removeFavorite(String pokemonId) async {
+    if (_favoritesCollection == null) return;
+
+    await _favoritesCollection!.doc(pokemonId).delete();
+  }
+
+  @override
+  Future<List<Pokemon>> getFavorites() async {
+    if (_favoritesCollection == null) return [];
+
+    final snapshot = await _favoritesCollection!.get();
+    return snapshot.docs.map((doc) => _pokemonFromFirestore(doc)).toList();
+  }
+
+  @override
+  Stream<List<Pokemon>> favoritesStream() {
+    if (_favoritesCollection == null) return Stream.value([]);
+
+    return _favoritesCollection!.snapshots().map((snapshot) {
+      return snapshot.docs.map((doc) => _pokemonFromFirestore(doc)).toList();
+    });
+  }
+
+  @override
+  Future<bool> isFavorite(String pokemonId) async {
+    if (_favoritesCollection == null) return false;
+
+    final doc = await _favoritesCollection!.doc(pokemonId).get();
+    return doc.exists;
+  }
+
+  @override
+  Future<void> clearAllFavorites() async {
+    if (_favoritesCollection == null) return;
+
+    final snapshot = await _favoritesCollection!.get();
+    for (var doc in snapshot.docs) {
+      await doc.reference.delete();
+    }
+  }
+
+  
+  Pokemon _pokemonFromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return Pokemon(
+      name: data[FavoriteField.name.name] as String,
+      url: data[FavoriteField.url.name] as String,
+      imageUrl: data[FavoriteField.imageUrl.name] as String?,
+    );
+  }
+}

--- a/lib/services/i_favorites_service.dart
+++ b/lib/services/i_favorites_service.dart
@@ -1,0 +1,11 @@
+import 'package:pokedex_app/models/pokemon.dart';
+
+
+abstract class IFavoritesService {
+  Future<void> addFavorite(Pokemon pokemon);
+  Future<void> removeFavorite(String pokemonId);
+  Future<List<Pokemon>> getFavorites();
+  Stream<List<Pokemon>> favoritesStream();
+  Future<bool> isFavorite(String pokemonId);
+  Future<void> clearAllFavorites();
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,11 +5,13 @@
 import FlutterMacOS
 import Foundation
 
+import cloud_firestore
 import firebase_auth
 import firebase_core
 import google_sign_in_ios
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,6 +137,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      sha256: fc1de79a62fe21615e9012f396070e6121838ef0d879475a4ec8320e79378208
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      sha256: "2d2ee96a32ec3dd22fb682295e9bed6336e49a43f056d7841690228adca3ee7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.4"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      sha256: "28c39f3d050bf669787ef13fa0890df2b4af236de864e2db0cc3897b857066cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   code_builder:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
+  cloud_firestore: ^6.1.0
   firebase_auth: ^6.1.2
   firebase_core: ^4.2.1
   flutter:

--- a/test/views/screens/home_screen_test.mocks.dart
+++ b/test/views/screens/home_screen_test.mocks.dart
@@ -3,12 +3,12 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i7;
-import 'dart:ui' as _i5;
+import 'dart:async' as _i5;
+import 'dart:ui' as _i6;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:pokedex_app/controllers/favorites_controller.dart' as _i3;
-import 'package:pokedex_app/controllers/pokemon_controller.dart' as _i6;
+import 'package:pokedex_app/controllers/pokemon_controller.dart' as _i7;
 import 'package:pokedex_app/models/pokemon.dart' as _i4;
 import 'package:pokedex_app/models/pokemon_detail.dart' as _i2;
 import 'package:pokedex_app/services/api_services.dart' as _i8;
@@ -57,9 +57,23 @@ class MockFavoritesController extends _i1.Mock
           as List<_i4.Pokemon>);
 
   @override
+  bool get isLoading =>
+      (super.noSuchMethod(Invocation.getter(#isLoading), returnValue: false)
+          as bool);
+
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
+
+  @override
+  _i5.Future<void> reloadFavorites() =>
+      (super.noSuchMethod(
+            Invocation.method(#reloadFavorites, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
   bool isFavorite(_i4.Pokemon? pokemon) =>
@@ -70,22 +84,40 @@ class MockFavoritesController extends _i1.Mock
           as bool);
 
   @override
-  void toggleFavorite(_i4.Pokemon? pokemon) => super.noSuchMethod(
-    Invocation.method(#toggleFavorite, [pokemon]),
-    returnValueForMissingStub: null,
-  );
+  _i5.Future<void> toggleFavorite(_i4.Pokemon? pokemon) =>
+      (super.noSuchMethod(
+            Invocation.method(#toggleFavorite, [pokemon]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  void addFavorite(_i4.Pokemon? pokemon) => super.noSuchMethod(
-    Invocation.method(#addFavorite, [pokemon]),
-    returnValueForMissingStub: null,
-  );
+  _i5.Future<void> addFavorite(_i4.Pokemon? pokemon) =>
+      (super.noSuchMethod(
+            Invocation.method(#addFavorite, [pokemon]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  void removeFavorite(_i4.Pokemon? pokemon) => super.noSuchMethod(
-    Invocation.method(#removeFavorite, [pokemon]),
-    returnValueForMissingStub: null,
-  );
+  _i5.Future<void> removeFavorite(_i4.Pokemon? pokemon) =>
+      (super.noSuchMethod(
+            Invocation.method(#removeFavorite, [pokemon]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> clearFavorites() =>
+      (super.noSuchMethod(
+            Invocation.method(#clearFavorites, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
   List<_i4.Pokemon> searchFavorites(String? query) =>
@@ -96,13 +128,13 @@ class MockFavoritesController extends _i1.Mock
           as List<_i4.Pokemon>);
 
   @override
-  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#addListener, [listener]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#removeListener, [listener]),
     returnValueForMissingStub: null,
   );
@@ -123,18 +155,18 @@ class MockFavoritesController extends _i1.Mock
 /// A class which mocks [PokemonController].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPokemonController extends _i1.Mock implements _i6.PokemonController {
+class MockPokemonController extends _i1.Mock implements _i7.PokemonController {
   MockPokemonController() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i7.Future<List<_i4.Pokemon>> fetchPokemon(int? offset, int? limit) =>
+  _i5.Future<List<_i4.Pokemon>> fetchPokemon(int? offset, int? limit) =>
       (super.noSuchMethod(
             Invocation.method(#fetchPokemon, [offset, limit]),
-            returnValue: _i7.Future<List<_i4.Pokemon>>.value(<_i4.Pokemon>[]),
+            returnValue: _i5.Future<List<_i4.Pokemon>>.value(<_i4.Pokemon>[]),
           )
-          as _i7.Future<List<_i4.Pokemon>>);
+          as _i5.Future<List<_i4.Pokemon>>);
 }
 
 /// A class which mocks [ApiServices].
@@ -146,45 +178,45 @@ class MockApiServices extends _i1.Mock implements _i8.ApiServices {
   }
 
   @override
-  _i7.Future<List<_i4.Pokemon>> fetchPokemon(int? offset, int? limit) =>
+  _i5.Future<List<_i4.Pokemon>> fetchPokemon(int? offset, int? limit) =>
       (super.noSuchMethod(
             Invocation.method(#fetchPokemon, [offset, limit]),
-            returnValue: _i7.Future<List<_i4.Pokemon>>.value(<_i4.Pokemon>[]),
+            returnValue: _i5.Future<List<_i4.Pokemon>>.value(<_i4.Pokemon>[]),
           )
-          as _i7.Future<List<_i4.Pokemon>>);
+          as _i5.Future<List<_i4.Pokemon>>);
 
   @override
-  _i7.Future<_i2.PokemonDetail> fetchPokemonDetail(String? url) =>
+  _i5.Future<_i2.PokemonDetail> fetchPokemonDetail(String? url) =>
       (super.noSuchMethod(
             Invocation.method(#fetchPokemonDetail, [url]),
-            returnValue: _i7.Future<_i2.PokemonDetail>.value(
+            returnValue: _i5.Future<_i2.PokemonDetail>.value(
               _FakePokemonDetail_0(
                 this,
                 Invocation.method(#fetchPokemonDetail, [url]),
               ),
             ),
           )
-          as _i7.Future<_i2.PokemonDetail>);
+          as _i5.Future<_i2.PokemonDetail>);
 
   @override
-  _i7.Future<void> prefetchPokemonDetails(List<_i4.Pokemon>? pokemonList) =>
+  _i5.Future<void> prefetchPokemonDetails(List<_i4.Pokemon>? pokemonList) =>
       (super.noSuchMethod(
             Invocation.method(#prefetchPokemonDetails, [pokemonList]),
-            returnValue: _i7.Future<void>.value(),
-            returnValueForMissingStub: _i7.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i7.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i7.Future<_i2.EvolutionChain> fetchEvolutionChain(String? speciesUrl) =>
+  _i5.Future<_i2.EvolutionChain> fetchEvolutionChain(String? speciesUrl) =>
       (super.noSuchMethod(
             Invocation.method(#fetchEvolutionChain, [speciesUrl]),
-            returnValue: _i7.Future<_i2.EvolutionChain>.value(
+            returnValue: _i5.Future<_i2.EvolutionChain>.value(
               _FakeEvolutionChain_1(
                 this,
                 Invocation.method(#fetchEvolutionChain, [speciesUrl]),
               ),
             ),
           )
-          as _i7.Future<_i2.EvolutionChain>);
+          as _i5.Future<_i2.EvolutionChain>);
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <cloud_firestore/cloud_firestore_plugin_c_api.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  CloudFirestorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
   FirebaseAuthPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  cloud_firestore
   firebase_auth
   firebase_core
 )


### PR DESCRIPTION
1. Added Cloud Firestore Dependency 
2. Created FavoritesService, which manages Firestore operations for favorites, and creates a collection structure 
3. updated Favorites controller now requires FavoritesService injection, loads favorites from Firestore 
4. Main.dart  I changed the HomeWrapper to inject FavoritesService into FavoritesController. I also added an auth state listener to clear favorites when the user signs out and reloads them when the user signs in. 
5. Enums Added :
FirestoreCollection: Defines collection names (users, favorites)
FavoriteField: Defines Firestore field names (name, url, imageUrl, timestamp)

fixed #12 

