### PR TITLE
fix: Improve user authentication handling to prevent null email values

### DIFF
--- a/lib/views/screens/auth_wrapper.dart
+++ b/lib/views/screens/auth_wrapper.dart
@@ -57,12 +57,12 @@ class AuthWrapper extends StatelessWidget {
           );
         }
 
-        // User is signed in
-        if (snapshot.hasData) {
+        // User is signed in with valid email
+        if (snapshot.hasData && snapshot.data?.email != null) {
           return HomeWrapper(themeController: themeController);
         }
 
-        // User is not signed in
+        // User is not signed in or has invalid auth data
         return LoginScreen();
       },
     );

--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -31,7 +31,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
       setState(() {
         _userProfile = UserProfile(
           name: user.displayName ?? 'Pokémon Trainer',
-          email: user.email ?? '',
+          email: user.email ?? '', // bugfix notes , this defaults to a string when email is null 
           joinedDate: user.metadata.creationTime ?? DateTime.now(),
           bio: 'Gotta catch \'em all!',
           profileImageUrl: user.photoURL,


### PR DESCRIPTION
fix #25 

In the AuthWrapper it checks if snap.has data to determine if a user is logged in . If a user is logged in but their email is NULL ( cant happen here because authentication in app only happens via Google sign in and Email/Password , would happen for anaymous sign in) , they get past the AuthWrapper. In ProfilesScreen , when user.email is null it results in a string then displays this empty string. 

The only way i can think this would happen in this app is if user gets deleted but still holds the auth token to login or if in future other ways of login are implemented like anonymous and phone number sign in. 

The Authwrapper now checks if the user exists and if the user has a valid email , if not returns them back to login screen. 