### PR TITLE
fix: Prevent Firebase re-initialization error by checking if apps are…

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,10 @@ import 'package:pokedex_app/views/screens/auth_wrapper.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  if (Firebase.apps.isEmpty) { // this will prevent re-initialization error
+    await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  }
+
 
   // FlutterNativeSplash.preserve(
   //   widgetsBinding: WidgetsFlutterBinding.ensureInitialized(),


### PR DESCRIPTION
I've added a check if (Firebase.apps.isEmpty) before initializing Firebase. This prevents the "Firebase already initialized" error that occurs during hot reload, as it will only initialize Firebase if no Firebase apps are currently running. Tested with hot reloads, error no more appears 

fix #21 