### PR TITLE
fix: Make favorite search case insensitive for better user experience

### DIFF
--- a/lib/controllers/favorites_controller.dart
+++ b/lib/controllers/favorites_controller.dart
@@ -90,10 +90,10 @@ class FavoritesController extends ChangeNotifier {
   List<Pokemon> searchFavorites(String query) {
     if (query.isEmpty) return favorites;
 
-    final lowerQuery = query.toLowerCase();
+    final lowerQuery = query.toLowerCase();// search is now case insensitive
     return _favorites.where((pokemon) {
       final name = pokemon.name.toLowerCase();
-      final id = pokemon.id;
+      final id = pokemon.id.toLowerCase();
       return name.contains(lowerQuery) || id.contains(lowerQuery);
     }).toList();
   }


### PR DESCRIPTION
The case-sensitive search was only for Favorites. In the home screen, it already converts Pokémon names and search queries to lowercase. I carried this over to the favorites screen to also be case-insensitive

fix #19  