### PR TITLE
feat: Add reusable ErrorStateWidget for improved error handling in De…

### DIFF
--- a/lib/views/screens/details_screen.dart
+++ b/lib/views/screens/details_screen.dart
@@ -3,6 +3,7 @@ import 'package:pokedex_app/controllers/favorites_controller.dart';
 import 'package:pokedex_app/models/pokemon.dart';
 import 'package:pokedex_app/models/pokemon_detail.dart';
 import 'package:pokedex_app/services/api_services.dart';
+import 'package:pokedex_app/views/widgets/error_state_widget.dart';
 
 class DetailsScreen extends StatefulWidget {
   final Pokemon pokemon;
@@ -152,44 +153,17 @@ class _DetailsScreenState extends State<DetailsScreen> {
               ),
             )
           : _error != null
-          ? Center(
-              child: Padding(
-                padding: EdgeInsets.all(24),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(Icons.error_outline, size: 64, color: Colors.red),
-                    SizedBox(height: 16),
-                    Text(
-                      'Failed to load Pokemon details',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    SizedBox(height: 8),
-                    Text(
-                      _error!,
-                      textAlign: TextAlign.center,
-                      style: TextStyle(color: Colors.red),
-                    ),
-                    SizedBox(height: 16),
-                    Text(
-                      'Pokemon: ${widget.pokemon.name}',
-                      style: TextStyle(color: textColor),
-                    ),
-                    Text(
-                      'URL: ${widget.pokemon.url}',
-                      style: TextStyle(color: textColor),
-                    ),
-                    SizedBox(height: 16),
-                    ElevatedButton(
-                      onPressed: _loadPokemonDetail,
-                      child: Text('Retry'),
-                    ),
-                  ],
-                ),
-              ),
+          ? ErrorStateWidget(
+              title: 'Failed to load Pokemon details',
+              errorMessage: _error!,
+              debugInfo: 'Pokemon: ${widget.pokemon.name}\nURL: ${widget.pokemon.url}',
+              onRetry: () {
+                setState(() {
+                  _error = null;
+                  _isLoading = true;
+                });
+                _loadPokemonDetail();
+              },
             )
           : CustomScrollView(
               slivers: [

--- a/lib/views/widgets/error_state_widget.dart
+++ b/lib/views/widgets/error_state_widget.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+/// A reusable error state widget that displays error information
+
+class ErrorStateWidget extends StatelessWidget {
+  final String title;
+  final String errorMessage;
+  final VoidCallback onRetry;
+  final String? debugInfo;
+  final IconData icon;
+  final Color iconColor;
+
+  const ErrorStateWidget({
+    super.key,
+    required this.title,
+    required this.errorMessage,
+    required this.onRetry,
+    this.debugInfo,
+    this.icon = Icons.error_outline,
+    this.iconColor = Colors.red,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final textColor = isDark ? Colors.white : Colors.black87;
+    final subtextColor = isDark ? Colors.grey[400] : Colors.grey[600];
+
+    return SafeArea(
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 64, color: iconColor),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: textColor,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                errorMessage,
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Colors.red),
+              ),
+              if (debugInfo != null) ...[
+                const SizedBox(height: 16),
+                Text(
+                  debugInfo!,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: subtextColor,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry'),
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 32,
+                    vertical: 12,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
I have implemented improvements to the existing error state, which already included a retry button, in order to align with the SOLID principles.

1. I created an `ErrorStateWidget` to display error states.
2. This `ErrorStateWidget` is designed to be open for extension through its parameters.
3. It extends a stateless widget, allowing it to be used wherever a widget is expected.
4. The `ErrorStateWidget` relies on abstraction, but I made some improvements to align with the SOLID principles.


fix #20 

