### PR TITLE
Fix unnecessary app rebuild on theme change by implementing ValueNoti…

### DIFF
--- a/lib/controllers/theme_controller.dart
+++ b/lib/controllers/theme_controller.dart
@@ -1,21 +1,48 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'package:pokedex_app/core/theme/app_theme.dart';
 
-class ThemeController extends ChangeNotifier {
-  ThemeMode _themeMode = ThemeMode.light;
+/// ThemeController manages the app's theme state.
+/// Uses ValueNotifier for efficient rebuilds - only widgets listening to this
+/// notifier will rebuild, not the entire app.
+///
+/// Follows Single Responsibility Principle - only manages theme state.
+/// Follows Dependency Inversion Principle - depends on AppTheme abstraction.
+class ThemeController {
+  // Using ValueNotifier instead of ChangeNotifier for more granular control
+  final ValueNotifier<AppTheme> _themeNotifier = ValueNotifier(AppTheme.light);
 
-  ThemeMode get themeMode => _themeMode;
+  /// Public getter for theme value notifier
+  /// Widgets can listen to this without rebuilding parent widgets
+  ValueListenable<AppTheme> get themeNotifier => _themeNotifier;
 
-  bool get isDarkMode => _themeMode == ThemeMode.dark;
+  /// Current theme value
+  AppTheme get currentTheme => _themeNotifier.value;
 
+  /// Check if current theme is dark mode
+  bool get isDarkMode => _themeNotifier.value.isDarkMode;
+
+  /// Check if current theme is light mode
+  bool get isLightMode => _themeNotifier.value.isLightMode;
+
+  /// Check if current theme is system mode
+  bool get isSystemMode => _themeNotifier.value.isSystemMode;
+
+  /// Toggle between light and dark themes
   void toggleTheme() {
-    _themeMode = _themeMode == ThemeMode.light
-        ? ThemeMode.dark
-        : ThemeMode.light;
-    notifyListeners();
+    _themeNotifier.value = _themeNotifier.value == AppTheme.light
+        ? AppTheme.dark
+        : AppTheme.light;
   }
 
-  void setTheme(ThemeMode mode) {
-    _themeMode = mode;
-    notifyListeners();
+  /// Set a specific theme
+  void setTheme(AppTheme theme) {
+    if (_themeNotifier.value != theme) {
+      _themeNotifier.value = theme;
+    }
+  }
+
+  /// Dispose the notifier when controller is no longer needed
+  void dispose() {
+    _themeNotifier.dispose();
   }
 }

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+enum AppTheme {
+  light,
+  dark,
+  system;
+
+  
+  ThemeMode get themeMode {
+    switch (this) {
+      case AppTheme.light:
+        return ThemeMode.light;
+      case AppTheme.dark:
+        return ThemeMode.dark;
+      case AppTheme.system:
+        return ThemeMode.system;
+    }
+  }
+
+  String get displayName {
+    switch (this) {
+      case AppTheme.light:
+        return 'Light';
+      case AppTheme.dark:
+        return 'Dark';
+      case AppTheme.system:
+        return 'System';
+    }
+  }
+
+  String get iconName {
+    switch (this) {
+      case AppTheme.light:
+        return 'light_mode';
+      case AppTheme.dark:
+        return 'dark_mode';
+      case AppTheme.system:
+        return 'brightness_auto';
+    }
+  }
+
+
+  bool get isDarkMode => this == AppTheme.dark;
+
+
+  bool get isLightMode => this == AppTheme.light;
+
+
+  bool get isSystemMode => this == AppTheme.system;
+}

--- a/lib/core/theme/app_theme_data.dart
+++ b/lib/core/theme/app_theme_data.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+class AppThemeData {
+
+  AppThemeData._();
+
+
+  static ThemeData get lightTheme {
+    return ThemeData.light().copyWith(
+      primaryColor: Colors.red,
+      colorScheme: const ColorScheme.light(
+        primary: Colors.red,
+        secondary: Colors.blue,
+      ),
+      scaffoldBackgroundColor: Colors.white,
+      cardTheme: CardThemeData(
+        elevation: 2,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+    );
+  }
+
+  
+  static ThemeData get darkTheme {
+    return ThemeData.dark().copyWith(
+      primaryColor: Colors.red,
+      colorScheme: const ColorScheme.dark(
+        primary: Colors.red,
+        secondary: Colors.blue,
+      ),
+      scaffoldBackgroundColor: Colors.grey.shade900,
+      cardTheme: CardThemeData(
+        elevation: 2,
+        color: Colors.grey[850],
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 // import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:pokedex_app/controllers/favorites_controller.dart';
 import 'package:pokedex_app/controllers/theme_controller.dart';
+import 'package:pokedex_app/core/theme/app_theme_data.dart';
 import 'package:pokedex_app/firebase_options.dart';
 import 'package:pokedex_app/services/favorites_service.dart';
 import 'package:pokedex_app/views/screens/home_screen.dart';
@@ -35,14 +36,6 @@ class _MainAppState extends State<MainApp> {
   final ThemeController _themeController = ThemeController();
 
   @override
-  void initState() {
-    super.initState();
-    _themeController.addListener(() {
-      setState(() {});
-    });
-  }
-
-  @override
   void dispose() {
     _themeController.dispose();
     super.dispose();
@@ -50,40 +43,20 @@ class _MainAppState extends State<MainApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Pokedex',
-      debugShowCheckedModeBanner: false,
-      themeMode: _themeController.themeMode,
-      theme: ThemeData.light().copyWith(
-        primaryColor: Colors.red,
-        colorScheme: ColorScheme.light(
-          primary: Colors.red,
-          secondary: Colors.blue,
-        ),
-        scaffoldBackgroundColor: Colors.white,
-        cardTheme: CardThemeData(
-          elevation: 2,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-        ),
-      ),
-      darkTheme: ThemeData.dark().copyWith(
-        primaryColor: Colors.red,
-        colorScheme: ColorScheme.dark(
-          primary: Colors.red,
-          secondary: Colors.blue,
-        ),
-        scaffoldBackgroundColor: Colors.grey[900],
-        cardTheme: CardThemeData(
-          elevation: 2,
-          color: Colors.grey[850],
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-        ),
-      ),
-      home: AuthWrapper(themeController: _themeController),
+
+    return ValueListenableBuilder(
+      valueListenable: _themeController.themeNotifier,
+      builder: (context, theme, child) {
+        return MaterialApp(
+          title: 'Pokedex',
+          debugShowCheckedModeBanner: false,
+          themeMode: theme.themeMode,
+          theme: AppThemeData.lightTheme,
+          darkTheme: AppThemeData.darkTheme,
+          home: child,
+        );
+      },
+      child: AuthWrapper(themeController: _themeController),
     );
   }
 }
@@ -107,9 +80,6 @@ class _HomeWrapperState extends State<HomeWrapper> {
     super.initState();
     _currentUser = FirebaseAuth.instance.currentUser;
     _favoritesController = FavoritesController(FavoritesService());
-    widget.themeController.addListener(() {
-      setState(() {});
-    });
 
     // Listen to auth state changes
     FirebaseAuth.instance.authStateChanges().listen((User? user) {

--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -214,28 +214,33 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       ),
                       SizedBox(height: 20),
 
-                      // Theme Toggle
-                      _buildSettingItem(
-                        icon: widget.themeController.isDarkMode
-                            ? Icons.dark_mode
-                            : Icons.light_mode,
-                        iconColor: widget.themeController.isDarkMode
-                            ? Colors.orange[300]
-                            : Colors.amber[700],
-                        title: 'Dark Mode',
-                        subtitle: widget.themeController.isDarkMode
-                            ? 'Enabled'
-                            : 'Disabled',
-                        trailing: Switch(
-                          value: widget.themeController.isDarkMode,
-                          onChanged: (value) {
-                            widget.themeController.toggleTheme();
-                          },
-                          activeTrackColor: Colors.black87,
-                        ),
-                        isDark: isDark,
-                        textColor: textColor,
-                        subtextColor: subtextColor,
+                      // Theme Toggle - Using ValueListenableBuilder to prevent unnecessary rebuilds
+                      ValueListenableBuilder(
+                        valueListenable: widget.themeController.themeNotifier,
+                        builder: (context, theme, child) {
+                          return _buildSettingItem(
+                            icon: theme.isDarkMode
+                                ? Icons.dark_mode
+                                : Icons.light_mode,
+                            iconColor: theme.isDarkMode
+                                ? Colors.orange[300]
+                                : Colors.amber[700],
+                            title: 'Dark Mode',
+                            subtitle: theme.isDarkMode
+                                ? 'Enabled'
+                                : 'Disabled',
+                            trailing: Switch(
+                              value: theme.isDarkMode,
+                              onChanged: (value) {
+                                widget.themeController.toggleTheme();
+                              },
+                              activeTrackColor: Colors.black87,
+                            ),
+                            isDark: isDark,
+                            textColor: textColor,
+                            subtextColor: subtextColor,
+                          );
+                        },
                       ),
                       SizedBox(height: 12),
 


### PR DESCRIPTION
The entire app was being rebuilt when switching themes because `setState()` was called in both `MainAppState` and `_HomeWrapperState`, leading to unnecessary rebuilds of the entire widget tree. To resolve this, I removed the manual `setState()` calls in `MainAppState` and implemented a `ValueListenableBuilder` to ensure that only the `MaterialApp` rebuilds when the theme changes. 

Additionally, I created an `AppTheme` enum that supports both light and dark modes. The `AppThemeData` class I developed is responsible for handling the creation of the theme data.


fix #37 