### PR TITLE
Refactor favorites handling on auth state changes; add reinitialize m…

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,14 +64,17 @@ class _HomeWrapperState extends State<HomeWrapper> {
     super.initState();
     _currentUser = FirebaseAuth.instance.currentUser;
 
-    // Listen to auth state changes and reload favorites
+    // Listen to auth state changes and reinitialize favorites
     FirebaseAuth.instance.authStateChanges().listen((User? user) {
       if (user == null && _currentUser != null) {
-        // User signed out - favorites will auto-update via stream
-      } else if (user != null && _currentUser?.uid != user.uid) {
-        // User signed in or switched - favorites will auto-update via stream
+        // User signed out - reinitialize to clear favorites
         if (mounted) {
-          context.read<FavoritesViewModel>().loadFavorites();
+          context.read<FavoritesViewModel>().reinitialize();
+        }
+      } else if (user != null && _currentUser?.uid != user.uid) {
+        // User signed in or switched - reinitialize for new user
+        if (mounted) {
+          context.read<FavoritesViewModel>().reinitialize();
         }
       }
       _currentUser = user;


### PR DESCRIPTION
Easy fix - 

This stream listener captured the current user's Firestore collection reference and never updated when users changed. So when User A signed in and added favorites, then signed out, and User B signed in, the app was still listening to User A's favorites stream.

Updated FavoritesViewModel:
Added a StreamSubscription field to track the active subscription
Added a reinitialize() method that:
Clears all cached favorites data
Cancels the old stream subscription
Creates a new stream subscription for the current user
Added a dispose() method to properly clean up when the view model is destroyed
Changed the auth state listener to call reinitialize() instead of loadFavorites()


fix #45 
